### PR TITLE
Use generated Vagrant ssh-config 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+vagrant_ssh_config
 .vagrant/
 secrets/
 .env

--- a/vangrant-inventory
+++ b/vangrant-inventory
@@ -2,11 +2,16 @@
 prometheus-server
 grafana-server
 
+[prometheus-deployment:vars]
+ansible_ssh_common_args='-F vagrant_ssh_config'
+
 [prometheus-server]
-192.168.1.51
+#192.168.1.51
+box_1
 
 [grafana-server]
-192.168.1.52
-
+#192.168.1.52
+box_2
 [targets]
-192.168.1.53
+#192.168.1.53
+box_3


### PR DESCRIPTION
Using ssh config generated by ansible when bringing up the boxes simplifies things. This ssh config also the vagrant generated ssh keys instead of the locally generated ones.
